### PR TITLE
(fix):Adjust do folder path could have spaces

### DIFF
--- a/lua/plugins/obsidian.lua
+++ b/lua/plugins/obsidian.lua
@@ -43,7 +43,7 @@ local function config()
     local function getObsidianWorkspaces()
         local vaults = {}
         if obsidian_vaults then
-            for vault in obsidian_vaults:gmatch('[^,%s]+') do
+            for vault in obsidian_vaults:gmatch('[^,]+') do
                 local w = { name = vault, path = vault }
                 table.insert(vaults, w)
             end


### PR DESCRIPTION
Problema:
quando havia espaço no caminho do arquivo do vault gerava erro devido o método `getObsidianWorkspaces` quebrar a string por `,` e `%s`